### PR TITLE
Throw informative error when config file missing

### DIFF
--- a/src/app/config/config.ts
+++ b/src/app/config/config.ts
@@ -10,6 +10,8 @@ config.set("priorities", CommandPriorities);
 
 if (existsSync("./evl-daemon.json")) {
   config.loadFile("./evl-daemon.json");
+} else {
+  throw new Error("Configuration file not found.");
 }
 
 config.validate();


### PR DESCRIPTION
The error displayed when the config file is missing now lets the user know that it's the config file missing what's the cause of the error!

Closes 115